### PR TITLE
Support new Zenhub API endpoint

### DIFF
--- a/lib/zenhub_ruby/client/api.rb
+++ b/lib/zenhub_ruby/client/api.rb
@@ -16,6 +16,14 @@ module ZenhubRuby
       def workspace_data(repo_name, workspace_id)
         get "/p2/workspaces/#{workspace_id}/repositories/#{github.repo_id(repo_name)}/board"
       end
+
+      def repo_releases(repo_name)
+        get "/p1/repositories/#{github.repo_id(repo_name)}/reports/releases"
+      end
+
+      def release_issues(release_id)
+        get "/p1/reports/release/#{release_id}/issues"
+      end
     end
   end
 end

--- a/lib/zenhub_ruby/client/api.rb
+++ b/lib/zenhub_ruby/client/api.rb
@@ -9,8 +9,9 @@ module ZenhubRuby
         get "/p1/repositories/#{github.repo_id(repo_name)}/issues/#{issue_number}/events"
       end
 
-      def board_data(repo_name)
-        get "/p1/repositories/#{github.repo_id(repo_name)}/board"
+      def board_data(repo_name, workspace_id)
+        get "/p2/workspaces/#{workspace_id}/repositories/#{github.repo_id(repo_name)}/board"
+
       end
     end
   end

--- a/lib/zenhub_ruby/client/api.rb
+++ b/lib/zenhub_ruby/client/api.rb
@@ -9,9 +9,12 @@ module ZenhubRuby
         get "/p1/repositories/#{github.repo_id(repo_name)}/issues/#{issue_number}/events"
       end
 
-      def board_data(repo_name, workspace_id)
-        get "/p2/workspaces/#{workspace_id}/repositories/#{github.repo_id(repo_name)}/board"
+      def board_data(repo_name)
+        get "/p1/repositories/#{github.repo_id(repo_name)}/board"
+      end
 
+      def workspace_data(repo_name, workspace_id)
+        get "/p2/workspaces/#{workspace_id}/repositories/#{github.repo_id(repo_name)}/board"
       end
     end
   end

--- a/lib/zenhub_ruby/connection.rb
+++ b/lib/zenhub_ruby/connection.rb
@@ -3,7 +3,7 @@ require 'faraday_middleware'
 
 module ZenhubRuby
   module Connection
-    END_POINT = 'https://api.zenhub.io'.freeze
+    END_POINT = 'https://api.zenhub.com'.freeze
 
     def get(path)
       api_connection.get(path)


### PR DESCRIPTION
Zenhub has added an API endpoint to fetch board data for a workspace. 

Their [documentation](https://github.com/ZenHubIO/API#get-a-zenhub-board-for-a-repository) references this new endpoint:

`GET /p2/workspaces/:workspace_id/repositories/:repo_id/board` 

for returning a "ZenHub Board for a repository". I thought they had replaced the old endpoint:

`GET /p1/repositories/:repo_id/board`

but it turns out it is listed under "Get the oldest Zenhub board for a repository" and still works, but will not return what you are expecting if you have multiple boards/workspaces.

This PR adds an api call to use the new endpoint which I needed.