### PR TITLE
Fix for deprecated api.zenhub.io endpoint

### DIFF
--- a/lib/zenhub_ruby/connection.rb
+++ b/lib/zenhub_ruby/connection.rb
@@ -3,7 +3,7 @@ require 'faraday_middleware'
 
 module ZenhubRuby
   module Connection
-    END_POINT = 'https://api.zenhub.io'.freeze
+    END_POINT = 'https://api.zenhub.com'.freeze
 
     def get(path)
       api_connection.get(path)


### PR DESCRIPTION
The .io endpoint has been deprecated and the Zenhub team now requires using api.zenhub.com