### PR TITLE
use .com for the rest API per the founder of Zenhub on twitter

### DIFF
--- a/lib/zenhub_ruby/connection.rb
+++ b/lib/zenhub_ruby/connection.rb
@@ -3,7 +3,7 @@ require 'faraday_middleware'
 
 module ZenhubRuby
   module Connection
-    END_POINT = 'https://api.zenhub.io'.freeze
+    END_POINT = 'https://api.zenhub.com'.freeze
 
     def get(path)
       api_connection.get(path)


### PR DESCRIPTION
Zenhub let their ssl cert for .io expire. AFAIK this fix is non breaking . At least in all my code I use Zenhub with.

https://twitter.com/georgecs/status/1585651538155937795?s=20&t=wuCJBVXrTFCSwespITDLgQ